### PR TITLE
feat: ➕ add StronglyTypedArray.prototype.filter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,8 @@ type Combine<T, U> = T extends undefined
   : T | U;
 
 type AnyPredicate1<T extends AnyArray, U extends boolean = boolean> = (
-  value: ElementOf<T>
+  value: ElementOf<T>,
+  index: number
 ) => U;
 
 type TupleToArray<T extends AnyArray> = ElementOf<T>[];
@@ -80,7 +81,7 @@ type TupleToArray<T extends AnyArray> = ElementOf<T>[];
 type PredicateType<
   Cb extends AnyPredicate1<T>,
   T extends AnyArray
-> = Cb extends (value: any) => value is infer P
+> = Cb extends (value: any, ...args: any[]) => value is infer P
   ? [P] extends [ElementOf<T>]
     ? P[]
     : TupleToArray<T>
@@ -132,7 +133,9 @@ class StronglyTypedArray<T extends AnyArray> {
     return this.#items[index];
   }
 
-  map<U>(callback: (value: ElementOf<T>) => U): StronglyTypedArray<Map<T, U>> {
+  map<U>(
+    callback: (value: ElementOf<T>, index: number) => U
+  ): StronglyTypedArray<Map<T, U>> {
     // @ts-expect-error: T => U
     this.#items = this.#items.map(callback);
     // @ts-expect-error: StronglyTypedArray<T> => StronglyTypedArray<U>

--- a/type/filter.type.ts
+++ b/type/filter.type.ts
@@ -1,0 +1,54 @@
+import { AssertTrue, IsExact } from "conditional-type-checks";
+import StronglyTypedArray from "../src";
+
+declare const numbers: number[];
+declare const number1Tuple: [number];
+declare const number2Tuple: [number, number];
+declare const number3Tuple: [number, number, number];
+
+const isOneToThree = (value: number): value is 1 | 2 | 3 =>
+  [1, 2, 3].includes(value);
+
+const staNumbers = new StronglyTypedArray(numbers);
+const staNumbers1 = staNumbers.filter(Boolean);
+const staNumbers2 = staNumbers.filter(isOneToThree);
+
+const staNumber1Tuple = new StronglyTypedArray(number1Tuple);
+const staNumber1Tuple1 = staNumber1Tuple.filter(Boolean);
+const staNumber1Tuple2 = staNumber1Tuple.filter(isOneToThree);
+
+const staNumber2Tuple = new StronglyTypedArray(number2Tuple);
+const staNumber2Tuple1 = staNumber2Tuple.filter(Boolean);
+const staNumber2Tuple2 = staNumber2Tuple.filter(isOneToThree);
+
+const staNumber3Tuple = new StronglyTypedArray(number3Tuple);
+const staNumber3Tuple1 = staNumber3Tuple.filter(Boolean);
+const staNumber3Tuple2 = staNumber3Tuple.filter(isOneToThree);
+
+type cases = [
+  AssertTrue<IsExact<typeof staNumbers, StronglyTypedArray<number[]>>>,
+  AssertTrue<IsExact<typeof staNumbers1, StronglyTypedArray<number[]>>>,
+  AssertTrue<IsExact<typeof staNumbers2, StronglyTypedArray<(1 | 2 | 3)[]>>>,
+  AssertTrue<IsExact<typeof staNumber1Tuple, StronglyTypedArray<[number]>>>,
+  AssertTrue<IsExact<typeof staNumber1Tuple1, StronglyTypedArray<number[]>>>,
+  AssertTrue<
+    IsExact<typeof staNumber1Tuple2, StronglyTypedArray<(1 | 2 | 3)[]>>
+  >,
+  AssertTrue<
+    IsExact<typeof staNumber2Tuple, StronglyTypedArray<[number, number]>>
+  >,
+  AssertTrue<IsExact<typeof staNumber2Tuple1, StronglyTypedArray<number[]>>>,
+  AssertTrue<
+    IsExact<typeof staNumber2Tuple2, StronglyTypedArray<(1 | 2 | 3)[]>>
+  >,
+  AssertTrue<
+    IsExact<
+      typeof staNumber3Tuple,
+      StronglyTypedArray<[number, number, number]>
+    >
+  >,
+  AssertTrue<IsExact<typeof staNumber3Tuple1, StronglyTypedArray<number[]>>>,
+  AssertTrue<
+    IsExact<typeof staNumber3Tuple2, StronglyTypedArray<(1 | 2 | 3)[]>>
+  >
+];

--- a/type/filter.type.ts
+++ b/type/filter.type.ts
@@ -9,30 +9,43 @@ declare const number3Tuple: [number, number, number];
 const isOneToThree = (value: number): value is 1 | 2 | 3 =>
   [1, 2, 3].includes(value);
 
+const isFirstElementOneToThree = (
+  value: number,
+  index: number
+): value is 1 | 2 | 3 => index === 0 && [1, 2, 3].includes(value);
+
 const staNumbers = new StronglyTypedArray(numbers);
 const staNumbers1 = staNumbers.filter(Boolean);
 const staNumbers2 = staNumbers.filter(isOneToThree);
+const staNumbers3 = staNumbers.filter(isFirstElementOneToThree);
 
 const staNumber1Tuple = new StronglyTypedArray(number1Tuple);
 const staNumber1Tuple1 = staNumber1Tuple.filter(Boolean);
 const staNumber1Tuple2 = staNumber1Tuple.filter(isOneToThree);
+const staNumber1Tuple3 = staNumber1Tuple.filter(isFirstElementOneToThree);
 
 const staNumber2Tuple = new StronglyTypedArray(number2Tuple);
 const staNumber2Tuple1 = staNumber2Tuple.filter(Boolean);
 const staNumber2Tuple2 = staNumber2Tuple.filter(isOneToThree);
+const staNumber2Tuple3 = staNumber2Tuple.filter(isFirstElementOneToThree);
 
 const staNumber3Tuple = new StronglyTypedArray(number3Tuple);
 const staNumber3Tuple1 = staNumber3Tuple.filter(Boolean);
 const staNumber3Tuple2 = staNumber3Tuple.filter(isOneToThree);
+const staNumber3Tuple3 = staNumber3Tuple.filter(isFirstElementOneToThree);
 
 type cases = [
   AssertTrue<IsExact<typeof staNumbers, StronglyTypedArray<number[]>>>,
   AssertTrue<IsExact<typeof staNumbers1, StronglyTypedArray<number[]>>>,
   AssertTrue<IsExact<typeof staNumbers2, StronglyTypedArray<(1 | 2 | 3)[]>>>,
+  AssertTrue<IsExact<typeof staNumbers3, StronglyTypedArray<(1 | 2 | 3)[]>>>,
   AssertTrue<IsExact<typeof staNumber1Tuple, StronglyTypedArray<[number]>>>,
   AssertTrue<IsExact<typeof staNumber1Tuple1, StronglyTypedArray<number[]>>>,
   AssertTrue<
     IsExact<typeof staNumber1Tuple2, StronglyTypedArray<(1 | 2 | 3)[]>>
+  >,
+  AssertTrue<
+    IsExact<typeof staNumber1Tuple3, StronglyTypedArray<(1 | 2 | 3)[]>>
   >,
   AssertTrue<
     IsExact<typeof staNumber2Tuple, StronglyTypedArray<[number, number]>>
@@ -40,6 +53,9 @@ type cases = [
   AssertTrue<IsExact<typeof staNumber2Tuple1, StronglyTypedArray<number[]>>>,
   AssertTrue<
     IsExact<typeof staNumber2Tuple2, StronglyTypedArray<(1 | 2 | 3)[]>>
+  >,
+  AssertTrue<
+    IsExact<typeof staNumber2Tuple3, StronglyTypedArray<(1 | 2 | 3)[]>>
   >,
   AssertTrue<
     IsExact<
@@ -50,5 +66,8 @@ type cases = [
   AssertTrue<IsExact<typeof staNumber3Tuple1, StronglyTypedArray<number[]>>>,
   AssertTrue<
     IsExact<typeof staNumber3Tuple2, StronglyTypedArray<(1 | 2 | 3)[]>>
+  >,
+  AssertTrue<
+    IsExact<typeof staNumber3Tuple3, StronglyTypedArray<(1 | 2 | 3)[]>>
   >
 ];

--- a/type/map.type.ts
+++ b/type/map.type.ts
@@ -9,11 +9,17 @@ declare const number3Tuple: [number, number, number];
 const staNumbers = new StronglyTypedArray(numbers);
 const staNumbersToStrings1 = staNumbers.map(String);
 const staNumbersToStrings2 = staNumbers.map((value) => value.toString());
+const staNumbersToStrings3 = staNumbers.map(
+  (value, index) => `${value}-${index}`
+);
 
 const staNumber1Tuple = new StronglyTypedArray(number1Tuple);
 const staNumber1TupleToString1Tuple1 = staNumber1Tuple.map(String);
 const staNumber1TupleToString1Tuple2 = staNumber1Tuple.map((value) =>
   value.toString()
+);
+const staNumber1TupleToString1Tuple3 = staNumber1Tuple.map(
+  (value, index) => `${value}-${index}`
 );
 
 const staNumber2Tuple = new StronglyTypedArray(number2Tuple);
@@ -21,11 +27,17 @@ const staNumber2TupleToString2Tuple1 = staNumber2Tuple.map(String);
 const staNumber2TupleToString2Tuple2 = staNumber2Tuple.map((value) =>
   value.toString()
 );
+const staNumber2TupleToString2Tuple3 = staNumber2Tuple.map(
+  (value, index) => `${value}-${index}`
+);
 
 const staNumber3Tuple = new StronglyTypedArray(number3Tuple);
 const staNumber3TupleToString3Tuple1 = staNumber3Tuple.map(String);
 const staNumber3TupleToString3Tuple2 = staNumber3Tuple.map((value) =>
   value.toString()
+);
+const staNumber3TupleToString3Tuple3 = staNumber3Tuple.map(
+  (value, index) => `${value}-${index}`
 );
 
 type cases = [
@@ -36,12 +48,18 @@ type cases = [
   AssertTrue<
     IsExact<typeof staNumbersToStrings2, StronglyTypedArray<string[]>>
   >,
+  AssertTrue<
+    IsExact<typeof staNumbersToStrings3, StronglyTypedArray<string[]>>
+  >,
   AssertTrue<IsExact<typeof staNumber1Tuple, StronglyTypedArray<[number]>>>,
   AssertTrue<
     IsExact<typeof staNumber1TupleToString1Tuple1, StronglyTypedArray<[string]>>
   >,
   AssertTrue<
     IsExact<typeof staNumber1TupleToString1Tuple2, StronglyTypedArray<[string]>>
+  >,
+  AssertTrue<
+    IsExact<typeof staNumber1TupleToString1Tuple3, StronglyTypedArray<[string]>>
   >,
   AssertTrue<
     IsExact<typeof staNumber2Tuple, StronglyTypedArray<[number, number]>>
@@ -60,6 +78,12 @@ type cases = [
   >,
   AssertTrue<
     IsExact<
+      typeof staNumber2TupleToString2Tuple3,
+      StronglyTypedArray<[string, string]>
+    >
+  >,
+  AssertTrue<
+    IsExact<
       typeof staNumber3Tuple,
       StronglyTypedArray<[number, number, number]>
     >
@@ -73,6 +97,12 @@ type cases = [
   AssertTrue<
     IsExact<
       typeof staNumber3TupleToString3Tuple2,
+      StronglyTypedArray<[string, string, string]>
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof staNumber3TupleToString3Tuple3,
       StronglyTypedArray<[string, string, string]>
     >
   >


### PR DESCRIPTION
## What

Added `StronglyTypedArray.prototype.filter` support

## Why

1. It has tuple support, e.g. `[string]`, `[number, number]`, etc
2. It's friendly with type guards