### PR TITLE
refactor: 🔄 combine class and function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,48 +94,30 @@ type LengthComparison = `>= ${number}`;
 
 type ExtractLength<S extends LengthComparison> = S extends `>= ${infer N}` ? `${N}` : `${number}`;
 
-class StronglyTypedArray<T extends AnyArray> {
-  #items: T;
+// TODO: replace with ReturnType<typeof sta<T>> for TS@4.7
+interface StronglyTypedArray<T extends AnyArray> {
+  at<N extends number>(index: N): Get<T, `${N}`>;
+  filter<Cb extends AnyPredicate1<T>>(predicate: Cb): StronglyTypedArray<PredicateType<Cb, T>>;
+  length<S extends LengthComparison>(condition: S, orThrows: () => Error): StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>>;
+  map<U>(callback: (value: ElementOf<T>, index: number) => U): StronglyTypedArray<Map<T, U>>;
+  toArray(): T;
+}
 
-  constructor(items: T) {
-    this.#items = items;
-  }
-
-  length<S extends LengthComparison>(condition: S, orThrows: () => Error): StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>> {
+const sta = <T extends AnyArray>(items: T): StronglyTypedArray<T> => ({
+  at: <N extends number>(index: N): Get<T, `${N}`> => items[index],
+  filter: <Cb extends AnyPredicate1<T>>(predicate: Cb) => sta(items.filter(predicate) as PredicateType<Cb, T>),
+  length: <S extends LengthComparison>(condition: S, orThrows: () => Error) => {
     const expectedLength = Number(condition.split(' ')[1]);
-    
-    if (this.#items.length >= expectedLength) {
-      return this as unknown as StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>>
+
+    if (items.length >= expectedLength) {
+      return sta(items as unknown as ToTuple<ElementOf<T>, ExtractLength<S>>);
     }
 
     throw orThrows();
-  }
+  },
+  map: <U>(callback: (value: ElementOf<T>, index: number) => U) => sta(items.map(callback) as Map<T, U>),
+  toArray: () => items,
+});
 
-  at<N extends number, S extends string = `${N}`>(index: N): Get<T, S> {
-    return this.#items[index];
-  }
-
-  map<U>(
-    callback: (value: ElementOf<T>, index: number) => U
-  ): StronglyTypedArray<Map<T, U>> {
-    // @ts-expect-error: T => U
-    this.#items = this.#items.map(callback);
-    // @ts-expect-error: StronglyTypedArray<T> => StronglyTypedArray<U>
-    return this;
-  }
-
-  filter<Cb extends AnyPredicate1<T>>(
-    callback: Cb
-  ): StronglyTypedArray<PredicateType<Cb, T>> {
-    // @ts-expect-error: T => U
-    this.#items = this.#items.filter(callback);
-    // @ts-expect-error: StronglyTypedArray<T> => StronglyTypedArray<U>
-    return this;
-  }
-
-  toArray(): T {
-    return this.#items;
-  }
-}
-
-export default StronglyTypedArray;
+export default sta;
+export type {StronglyTypedArray}

--- a/type/at.type.ts
+++ b/type/at.type.ts
@@ -1,9 +1,9 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import StronglyTypedArray from "../src";
+import sta from "../src";
 
 declare const numbers: number[];
 
-const staNumbers = new StronglyTypedArray(numbers);
+const staNumbers = sta(numbers);
 
 const firstOptional = staNumbers.length('>= 0', () => new Error('Length cannot be negative')).at(0);
 const first = staNumbers.length('>= 1', () => new Error('Missing elements')).at(0);

--- a/type/filter.type.ts
+++ b/type/filter.type.ts
@@ -1,5 +1,5 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import StronglyTypedArray from "../src";
+import sta, {StronglyTypedArray} from "../src";
 
 declare const numbers: number[];
 declare const number1Tuple: [number];
@@ -14,22 +14,22 @@ const isFirstElementOneToThree = (
   index: number
 ): value is 1 | 2 | 3 => index === 0 && [1, 2, 3].includes(value);
 
-const staNumbers = new StronglyTypedArray(numbers);
+const staNumbers = sta(numbers);
 const staNumbers1 = staNumbers.filter(Boolean);
 const staNumbers2 = staNumbers.filter(isOneToThree);
 const staNumbers3 = staNumbers.filter(isFirstElementOneToThree);
 
-const staNumber1Tuple = new StronglyTypedArray(number1Tuple);
+const staNumber1Tuple = sta(number1Tuple);
 const staNumber1Tuple1 = staNumber1Tuple.filter(Boolean);
 const staNumber1Tuple2 = staNumber1Tuple.filter(isOneToThree);
 const staNumber1Tuple3 = staNumber1Tuple.filter(isFirstElementOneToThree);
 
-const staNumber2Tuple = new StronglyTypedArray(number2Tuple);
+const staNumber2Tuple = sta(number2Tuple);
 const staNumber2Tuple1 = staNumber2Tuple.filter(Boolean);
 const staNumber2Tuple2 = staNumber2Tuple.filter(isOneToThree);
 const staNumber2Tuple3 = staNumber2Tuple.filter(isFirstElementOneToThree);
 
-const staNumber3Tuple = new StronglyTypedArray(number3Tuple);
+const staNumber3Tuple = sta(number3Tuple);
 const staNumber3Tuple1 = staNumber3Tuple.filter(Boolean);
 const staNumber3Tuple2 = staNumber3Tuple.filter(isOneToThree);
 const staNumber3Tuple3 = staNumber3Tuple.filter(isFirstElementOneToThree);

--- a/type/map.type.ts
+++ b/type/map.type.ts
@@ -1,19 +1,19 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import StronglyTypedArray from "../src";
+import sta, {StronglyTypedArray} from "../src";
 
 declare const numbers: number[];
 declare const number1Tuple: [number];
 declare const number2Tuple: [number, number];
 declare const number3Tuple: [number, number, number];
 
-const staNumbers = new StronglyTypedArray(numbers);
+const staNumbers = sta(numbers);
 const staNumbersToStrings1 = staNumbers.map(String);
 const staNumbersToStrings2 = staNumbers.map((value) => value.toString());
 const staNumbersToStrings3 = staNumbers.map(
   (value, index) => `${value}-${index}`
 );
 
-const staNumber1Tuple = new StronglyTypedArray(number1Tuple);
+const staNumber1Tuple = sta(number1Tuple);
 const staNumber1TupleToString1Tuple1 = staNumber1Tuple.map(String);
 const staNumber1TupleToString1Tuple2 = staNumber1Tuple.map((value) =>
   value.toString()
@@ -22,7 +22,7 @@ const staNumber1TupleToString1Tuple3 = staNumber1Tuple.map(
   (value, index) => `${value}-${index}`
 );
 
-const staNumber2Tuple = new StronglyTypedArray(number2Tuple);
+const staNumber2Tuple = sta(number2Tuple);
 const staNumber2TupleToString2Tuple1 = staNumber2Tuple.map(String);
 const staNumber2TupleToString2Tuple2 = staNumber2Tuple.map((value) =>
   value.toString()
@@ -31,7 +31,7 @@ const staNumber2TupleToString2Tuple3 = staNumber2Tuple.map(
   (value, index) => `${value}-${index}`
 );
 
-const staNumber3Tuple = new StronglyTypedArray(number3Tuple);
+const staNumber3Tuple = sta(number3Tuple);
 const staNumber3TupleToString3Tuple1 = staNumber3Tuple.map(String);
 const staNumber3TupleToString3Tuple2 = staNumber3Tuple.map((value) =>
   value.toString()

--- a/type/toArray.type.ts
+++ b/type/toArray.type.ts
@@ -1,28 +1,28 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import StronglyTypedArray from "../src";
+import sta, {StronglyTypedArray} from "../src";
 
 declare const numbers: number[];
 declare const number1Tuple: [number];
 declare const number2Tuple: [number, number];
 declare const number3Tuple: [number, number, number];
 
-const staNumbers = new StronglyTypedArray(numbers);
+const staNumbers = sta(numbers);
 const strings1 = staNumbers.map(String).toArray();
 const strings2 = staNumbers.map((value) => value.toString()).toArray();
 
-const staNumber1Tuple = new StronglyTypedArray(number1Tuple);
+const staNumber1Tuple = sta(number1Tuple);
 const string1Tuple1 = staNumber1Tuple.map(String).toArray();
 const string1Tuple2 = staNumber1Tuple
   .map((value) => value.toString())
   .toArray();
 
-const staNumber2Tuple = new StronglyTypedArray(number2Tuple);
+const staNumber2Tuple = sta(number2Tuple);
 const string2Tuple1 = staNumber2Tuple.map(String).toArray();
 const string2Tuple2 = staNumber2Tuple
   .map((value) => value.toString())
   .toArray();
 
-const staNumber3Tuple = new StronglyTypedArray(number3Tuple);
+const staNumber3Tuple = sta(number3Tuple);
 const string3Tuple1 = staNumber3Tuple.map(String).toArray();
 const string3Tuple2 = staNumber3Tuple
   .map((value) => value.toString())


### PR DESCRIPTION
## What

Combine class and function declarations

## Why

1. Using function `sta` is easier as it's utility function
2. Using class is important as all methods will be in prototype and we don't need to dynamically create them after each `filter`, `map` and `length` call