### PR TITLE
test: 🧪 always use toArray

### DIFF
--- a/type/at.type.ts
+++ b/type/at.type.ts
@@ -5,14 +5,30 @@ declare const numbers: number[];
 
 const staNumbers = sta(numbers);
 
-const firstOptional = staNumbers.length('>= 0', () => new Error('Length cannot be negative')).at(0);
-const first = staNumbers.length('>= 1', () => new Error('Missing elements')).at(0);
-const secondOptional = staNumbers.length('>= 1', () => new Error('Missing elements')).at(1);
-const second = staNumbers.length('>= 2', () => new Error('Missing elements')).at(1);
-const beforeLastOptional = staNumbers.length('>= 1', () => new Error('Missing elements')).at(-2);
-const beforeLast = staNumbers.length('>= 2', () => new Error('Missing elements')).at(-2);
-const lastOptional = staNumbers.length('>= 0', () => new Error('Length cannot be negative')).at(-1);
-const last = staNumbers.length('>= 1', () => new Error('Missing elements')).at(-1);
+const firstOptional = staNumbers
+  .length(">= 0", () => new Error("Length cannot be negative"))
+  .at(0);
+const first = staNumbers
+  .length(">= 1", () => new Error("Missing elements"))
+  .at(0);
+const secondOptional = staNumbers
+  .length(">= 1", () => new Error("Missing elements"))
+  .at(1);
+const second = staNumbers
+  .length(">= 2", () => new Error("Missing elements"))
+  .at(1);
+const beforeLastOptional = staNumbers
+  .length(">= 1", () => new Error("Missing elements"))
+  .at(-2);
+const beforeLast = staNumbers
+  .length(">= 2", () => new Error("Missing elements"))
+  .at(-2);
+const lastOptional = staNumbers
+  .length(">= 0", () => new Error("Length cannot be negative"))
+  .at(-1);
+const last = staNumbers
+  .length(">= 1", () => new Error("Missing elements"))
+  .at(-1);
 
 type cases = [
   AssertTrue<IsExact<typeof firstOptional, number | undefined>>,
@@ -22,5 +38,5 @@ type cases = [
   AssertTrue<IsExact<typeof beforeLast, number>>,
   AssertTrue<IsExact<typeof beforeLastOptional, number | undefined>>,
   AssertTrue<IsExact<typeof last, number>>,
-  AssertTrue<IsExact<typeof lastOptional, number | undefined>>,
+  AssertTrue<IsExact<typeof lastOptional, number | undefined>>
 ];

--- a/type/length.type.ts
+++ b/type/length.type.ts
@@ -1,0 +1,208 @@
+import { AssertTrue, IsExact } from "conditional-type-checks";
+import sta from "../src";
+
+declare const numbers: number[];
+
+const staNumbers = sta(numbers);
+
+const sameNumbers = staNumbers
+  .length(">= 0", () => new Error("Length cannot be negative"))
+  .toArray();
+const numbers1 = staNumbers
+  .length(">= 1", () => new Error("Expected to have at least 1 element"))
+  .toArray();
+const numbers2 = staNumbers
+  .length(">= 2", () => new Error("Expected to have at least 2 element"))
+  .toArray();
+const numbers3 = staNumbers
+  .length(">= 3", () => new Error("Expected to have at least 3 element"))
+  .toArray();
+const numbers4 = staNumbers
+  .length(">= 4", () => new Error("Expected to have at least 4 element"))
+  .toArray();
+const numbers5 = staNumbers
+  .length(">= 5", () => new Error("Expected to have at least 5 element"))
+  .toArray();
+const numbers6 = staNumbers
+  .length(">= 6", () => new Error("Expected to have at least 6 element"))
+  .toArray();
+const numbers7 = staNumbers
+  .length(">= 7", () => new Error("Expected to have at least 7 element"))
+  .toArray();
+const numbers8 = staNumbers
+  .length(">= 8", () => new Error("Expected to have at least 8 element"))
+  .toArray();
+const numbers9 = staNumbers
+  .length(">= 9", () => new Error("Expected to have at least 9 element"))
+  .toArray();
+const numbers10 = staNumbers
+  .length(">= 10", () => new Error("Expected to have at least 10 element"))
+  .toArray();
+
+type cases = [
+  AssertTrue<IsExact<typeof sameNumbers, number[]>>,
+  AssertTrue<IsExact<typeof numbers1, [number, ...number[], number]>>,
+  AssertTrue<
+    IsExact<typeof numbers2, [number, number, ...number[], number, number]>
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers3,
+      [number, number, number, ...number[], number, number, number]
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers4,
+      [
+        number,
+        number,
+        number,
+        number,
+        ...number[],
+        number,
+        number,
+        number,
+        number
+      ]
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers5,
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        ...number[],
+        number,
+        number,
+        number,
+        number,
+        number
+      ]
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers6,
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        ...number[],
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+      ]
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers7,
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        ...number[],
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+      ]
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers8,
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        ...number[],
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+      ]
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers9,
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        ...number[],
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+      ]
+    >
+  >,
+  AssertTrue<
+    IsExact<
+      typeof numbers10,
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        ...number[],
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
+      ]
+    >
+  >
+];

--- a/type/map.type.ts
+++ b/type/map.type.ts
@@ -1,5 +1,5 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import sta, { StronglyTypedArray } from "../src";
+import sta from "../src";
 
 declare const numbers: number[];
 declare const number1Tuple: [number];

--- a/type/map.type.ts
+++ b/type/map.type.ts
@@ -1,5 +1,5 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import sta, {StronglyTypedArray} from "../src";
+import sta, { StronglyTypedArray } from "../src";
 
 declare const numbers: number[];
 declare const number1Tuple: [number];
@@ -7,103 +7,56 @@ declare const number2Tuple: [number, number];
 declare const number3Tuple: [number, number, number];
 
 const staNumbers = sta(numbers);
-const staNumbersToStrings1 = staNumbers.map(String);
-const staNumbersToStrings2 = staNumbers.map((value) => value.toString());
-const staNumbersToStrings3 = staNumbers.map(
-  (value, index) => `${value}-${index}`
-);
+const numbersToStrings1 = staNumbers.map(String).toArray();
+const numbersToStrings2 = staNumbers.map((value) => value.toString()).toArray();
+const numbersToStrings3 = staNumbers
+  .map((value, index) => `${value}-${index}`)
+  .toArray();
 
 const staNumber1Tuple = sta(number1Tuple);
-const staNumber1TupleToString1Tuple1 = staNumber1Tuple.map(String);
-const staNumber1TupleToString1Tuple2 = staNumber1Tuple.map((value) =>
-  value.toString()
-);
-const staNumber1TupleToString1Tuple3 = staNumber1Tuple.map(
-  (value, index) => `${value}-${index}`
-);
+const number1TupleToString1Tuple1 = staNumber1Tuple.map(String).toArray();
+const number1TupleToString1Tuple2 = staNumber1Tuple
+  .map((value) => value.toString())
+  .toArray();
+const number1TupleToString1Tuple3 = staNumber1Tuple
+  .map((value, index) => `${value}-${index}`)
+  .toArray();
 
 const staNumber2Tuple = sta(number2Tuple);
-const staNumber2TupleToString2Tuple1 = staNumber2Tuple.map(String);
-const staNumber2TupleToString2Tuple2 = staNumber2Tuple.map((value) =>
-  value.toString()
-);
-const staNumber2TupleToString2Tuple3 = staNumber2Tuple.map(
-  (value, index) => `${value}-${index}`
-);
+const number2TupleToString2Tuple1 = staNumber2Tuple.map(String).toArray();
+const number2TupleToString2Tuple2 = staNumber2Tuple
+  .map((value) => value.toString())
+  .toArray();
+const number2TupleToString2Tuple3 = staNumber2Tuple
+  .map((value, index) => `${value}-${index}`)
+  .toArray();
 
 const staNumber3Tuple = sta(number3Tuple);
-const staNumber3TupleToString3Tuple1 = staNumber3Tuple.map(String);
-const staNumber3TupleToString3Tuple2 = staNumber3Tuple.map((value) =>
-  value.toString()
-);
-const staNumber3TupleToString3Tuple3 = staNumber3Tuple.map(
-  (value, index) => `${value}-${index}`
-);
+const number3TupleToString3Tuple1 = staNumber3Tuple.map(String).toArray();
+const number3TupleToString3Tuple2 = staNumber3Tuple
+  .map((value) => value.toString())
+  .toArray();
+const number3TupleToString3Tuple3 = staNumber3Tuple
+  .map((value, index) => `${value}-${index}`)
+  .toArray();
 
 type cases = [
-  AssertTrue<IsExact<typeof staNumbers, StronglyTypedArray<number[]>>>,
+  AssertTrue<IsExact<typeof numbersToStrings1, string[]>>,
+  AssertTrue<IsExact<typeof numbersToStrings2, string[]>>,
+  AssertTrue<IsExact<typeof numbersToStrings3, string[]>>,
+  AssertTrue<IsExact<typeof number1TupleToString1Tuple1, [string]>>,
+  AssertTrue<IsExact<typeof number1TupleToString1Tuple2, [string]>>,
+  AssertTrue<IsExact<typeof number1TupleToString1Tuple3, [string]>>,
+  AssertTrue<IsExact<typeof number2TupleToString2Tuple1, [string, string]>>,
+  AssertTrue<IsExact<typeof number2TupleToString2Tuple2, [string, string]>>,
+  AssertTrue<IsExact<typeof number2TupleToString2Tuple3, [string, string]>>,
   AssertTrue<
-    IsExact<typeof staNumbersToStrings1, StronglyTypedArray<string[]>>
+    IsExact<typeof number3TupleToString3Tuple1, [string, string, string]>
   >,
   AssertTrue<
-    IsExact<typeof staNumbersToStrings2, StronglyTypedArray<string[]>>
+    IsExact<typeof number3TupleToString3Tuple2, [string, string, string]>
   >,
   AssertTrue<
-    IsExact<typeof staNumbersToStrings3, StronglyTypedArray<string[]>>
-  >,
-  AssertTrue<IsExact<typeof staNumber1Tuple, StronglyTypedArray<[number]>>>,
-  AssertTrue<
-    IsExact<typeof staNumber1TupleToString1Tuple1, StronglyTypedArray<[string]>>
-  >,
-  AssertTrue<
-    IsExact<typeof staNumber1TupleToString1Tuple2, StronglyTypedArray<[string]>>
-  >,
-  AssertTrue<
-    IsExact<typeof staNumber1TupleToString1Tuple3, StronglyTypedArray<[string]>>
-  >,
-  AssertTrue<
-    IsExact<typeof staNumber2Tuple, StronglyTypedArray<[number, number]>>
-  >,
-  AssertTrue<
-    IsExact<
-      typeof staNumber2TupleToString2Tuple1,
-      StronglyTypedArray<[string, string]>
-    >
-  >,
-  AssertTrue<
-    IsExact<
-      typeof staNumber2TupleToString2Tuple2,
-      StronglyTypedArray<[string, string]>
-    >
-  >,
-  AssertTrue<
-    IsExact<
-      typeof staNumber2TupleToString2Tuple3,
-      StronglyTypedArray<[string, string]>
-    >
-  >,
-  AssertTrue<
-    IsExact<
-      typeof staNumber3Tuple,
-      StronglyTypedArray<[number, number, number]>
-    >
-  >,
-  AssertTrue<
-    IsExact<
-      typeof staNumber3TupleToString3Tuple1,
-      StronglyTypedArray<[string, string, string]>
-    >
-  >,
-  AssertTrue<
-    IsExact<
-      typeof staNumber3TupleToString3Tuple2,
-      StronglyTypedArray<[string, string, string]>
-    >
-  >,
-  AssertTrue<
-    IsExact<
-      typeof staNumber3TupleToString3Tuple3,
-      StronglyTypedArray<[string, string, string]>
-    >
+    IsExact<typeof number3TupleToString3Tuple3, [string, string, string]>
   >
 ];

--- a/type/toArray.type.ts
+++ b/type/toArray.type.ts
@@ -1,5 +1,5 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import sta, {StronglyTypedArray} from "../src";
+import sta from "../src";
 
 declare const numbers: number[];
 declare const number1Tuple: [number];

--- a/type/tuple.type.ts
+++ b/type/tuple.type.ts
@@ -1,14 +1,14 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import sta, {StronglyTypedArray} from "../src";
+import sta from "../src";
 
-const staNumberTuple1 = sta([1]);
-const staNumberTuple2 = sta([1, 2]);
-const staNumberTuple3 = sta([1, 2, 3]);
-const staNumberTuple4 = sta([1, 2, 3, 4]);
+const staNumberTuple1 = sta([1]).toArray();
+const staNumberTuple2 = sta([1, 2]).toArray();
+const staNumberTuple3 = sta([1, 2, 3]).toArray();
+const staNumberTuple4 = sta([1, 2, 3, 4]).toArray();
 
 type cases = [
-  AssertTrue<IsExact<typeof staNumberTuple1, StronglyTypedArray<[number]>>>,
-  AssertTrue<IsExact<typeof staNumberTuple2, StronglyTypedArray<[number, number]>>>,
-  AssertTrue<IsExact<typeof staNumberTuple3, StronglyTypedArray<[number, number, number]>>>,
-  AssertTrue<IsExact<typeof staNumberTuple4, StronglyTypedArray<[number, number, number, number]>>>,
+  AssertTrue<IsExact<typeof staNumberTuple1, [number]>>,
+  AssertTrue<IsExact<typeof staNumberTuple2, [number, number]>>,
+  AssertTrue<IsExact<typeof staNumberTuple3, [number, number, number]>>,
+  AssertTrue<IsExact<typeof staNumberTuple4, [number, number, number, number]>>
 ];


### PR DESCRIPTION
## What

1. Use `toArray` in all tests
2. Add `toArray`-only tests

## Why

`StronglyTypedArray` is a long word, so it will reduce the number of lines