### PR TITLE
ci: ➕ add prepare for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Added script `npm prepare`

## Why

When we call `npm release`, `prepare` script is run in the background, so we make sure that we release built version